### PR TITLE
fix(windows): Fix build failure on Windows

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -697,11 +697,11 @@ AUTOMAKESOURCES = $(automake_in) $(aclocal_in)
 info_TEXINFOS = doc/automake.texi doc/automake-history.texi
 doc_automake_TEXINFOS = doc/fdl.texi
 doc_automake_history_TEXINFOS = doc/fdl.texi
-man1_MANS = \
-  doc/aclocal.1 \
-  doc/automake.1 \
-  doc/aclocal-$(APIVERSION).1 \
-  doc/automake-$(APIVERSION).1
+man1_MANS = 
+#  doc/aclocal.1 \
+#  doc/automake.1 \
+#  doc/aclocal-$(APIVERSION).1 \
+#  doc/automake-$(APIVERSION).1
 
 update_mans = \
   $(AM_V_GEN): \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,3 @@
-jobs:
 - template: .ci/build.yaml
   parameters:
     host: Windows


### PR DESCRIPTION
__Issue:__

The windows build is failing due to this error:
```
    # esy-build-package: running: "make"

      GEN      bin/automake
      GEN      bin/aclocal
      GEN      bin/aclocal-1.16
      GEN      bin/automake-1.16
      GEN      t/ax/shell-no-trail-bslash
      GEN      t/ax/cc-no-c-o
      GEN      runtest
      GEN      doc/aclocal.1
      GEN      doc/automake.1
      GEN      lib/Automake/Config.pm
      GEN      doc/aclocal-1.16.1
    help2man: can't get `--help' info from aclocal-1.16
    Try `--no-discard-stderr' if option outputs to stderr
    make: *** [Makefile:3693: doc/aclocal-1.16.1] Error 2
    error: command failed: "make" (exited with 2)
```

__Fix (er, hack, really...):__ Skip man page generation on windows to unblock builds